### PR TITLE
Ignore Python cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /doc/tags
+*.pyc


### PR DESCRIPTION
It is a tiny thing I know, but it set the OCD twitching when my master vim repo told me that submodule had untracked changes :-)
